### PR TITLE
Remove forced maxLines on Description

### DIFF
--- a/lib/intro_slider.dart
+++ b/lib/intro_slider.dart
@@ -463,7 +463,6 @@ class IntroSliderState extends State<IntroSlider>
               description ?? "",
               style: styleDescription ??
                   TextStyle(color: Colors.white, fontSize: 18.0),
-              maxLines: 3,
               textAlign: TextAlign.center,
               overflow: TextOverflow.ellipsis,
             ),


### PR DESCRIPTION
The description should be left to be whatever length the developer needs. I can't think of any case where a developer would want the text of the description to be cut off. If it should have less text, then they can reduce the word count.